### PR TITLE
Added wl.offline_access scope to support refresh token

### DIFF
--- a/Bex/BexClient.cs
+++ b/Bex/BexClient.cs
@@ -98,19 +98,31 @@ namespace Bex
         /// <returns></returns>
         public string CreateAuthenticationUrl(IEnumerable<Scope> scopes, string redirectUrl = null)
         {
+            return this.CreateAuthenticationUrl(scopes.Select(x => x.GetDescription()));
+        }
+
+        /// <summary>
+        /// Creates the authentication URL.
+        /// </summary>
+        /// <param name="scopes">The scopes as their string representations. Allows for adding additional scopes not exposed through the <see cref="Scope"/> enum.</param>
+        /// <param name="redirectUrl">This is optional. If using a WebAuthenticationBroker, don't set this, if you're using a website, you may want to set it</param>
+        /// <returns></returns>
+        public string CreateAuthenticationUrl(IEnumerable<string> scopes, string redirectUrl = null)
+        {
             var uriBuilder = new UriBuilder(AuthUrl);
             var query = new StringBuilder();
 
             query.AppendFormat("redirect_uri={0}", Uri.EscapeUriString(redirectUrl ?? RedirectUri));
             query.AppendFormat("&client_id={0}", Uri.EscapeUriString(ClientId));
 
-            var scopesString = string.Join(" ", scopes.Select(x => x.GetDescription()));
+            var scopesString = string.Join(" ", scopes);
             query.AppendFormat("&scope={0}", Uri.EscapeUriString(scopesString));
             query.Append("&response_type=code");
 
             uriBuilder.Query = query.ToString();
 
             return uriBuilder.Uri.ToString();
+
         }
 
         /// <summary>

--- a/Bex/IBexClient.cs
+++ b/Bex/IBexClient.cs
@@ -45,6 +45,14 @@ namespace Bex
         string CreateAuthenticationUrl(IEnumerable<Scope> scopes, string redirectUrl = null);
 
         /// <summary>
+        /// Creates the authentication URL.
+        /// </summary>
+        /// <param name="scopes">The scopes as their string representations.</param>
+        /// <param name="redirectUrl">This is optional. If using a WebAuthenticationBroker, don't set this, if you're using a website, you may want to set it</param>
+        /// <returns></returns>
+        string CreateAuthenticationUrl(IEnumerable<string> scopes, string redirectUrl = null);
+
+        /// <summary>
         /// Creates the sign out URL.
         /// </summary>
         /// <returns></returns>

--- a/Bex/Scope.cs
+++ b/Bex/Scope.cs
@@ -14,9 +14,6 @@ namespace Bex
         ActivityLocation,
 
         [Description("mshealth.ReadProfile")]
-        Profile,
-
-        [Description("wl.offline_access")]
-        Offline
+        Profile
     }
 }

--- a/Bex/Scope.cs
+++ b/Bex/Scope.cs
@@ -14,6 +14,9 @@ namespace Bex
         ActivityLocation,
 
         [Description("mshealth.ReadProfile")]
-        Profile
+        Profile,
+
+        [Description("wl.offline_access")]
+        Offline
     }
 }

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ For usage and an overview, please go to http://metronuggets.com/2015/07/10/intro
 
 ## Nuget
 Install from Nuget https://www.nuget.org/packages/Bex/
+
+## Updates
+#### [James Croft](https://github.com/jamesmcroft)
+3/3/2016 - Added Offline scope to return a refresh token as part of the authentication process.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Install from Nuget https://www.nuget.org/packages/Bex/
 
 ## Updates
 #### [James Croft](https://github.com/jamesmcroft)
-3/3/2016 - Added Offline scope to return a refresh token as part of the authentication process.
+3/3/2016 - Added support to extend the creation of a URL with more scopes as their string representation


### PR DESCRIPTION
In order to keep a user logged into an application I'm working on, I required the refresh token to be returned as part of the authentication process. Added it to the Scopes enum. 

Possibly need to look into a different way of passing the scopes into the BexClient as some developers might want to add more Live specific scopes which would require adding them to the enum and going through this same cycle. 
